### PR TITLE
provisionを監視対象から外す

### DIFF
--- a/wp/.gitignore
+++ b/wp/.gitignore
@@ -8,7 +8,7 @@ spec
 ansible.cfg
 LICENSE
 README.md
-
+provision/*
 wordpress/*
 !wordpress/wp-content/
 wordpress/wp-content/*


### PR DESCRIPTION
立ち上げの共有が終了したので、wordpressの共有ファイルからprovisionを外した。