### PR TITLE
 #109 パンくずの実装

### DIFF
--- a/resource/assets/sass/index.scss
+++ b/resource/assets/sass/index.scss
@@ -32,6 +32,7 @@
 @import "object/layout/main";
 @import "object/layout/contact";
 @import "object/layout/sidebar";
+@import "object/layout/service";
 
 @import "object/project/bg";
 @import "object/project/box";
@@ -42,6 +43,8 @@
 @import "object/project/form";
 @import "object/project/article";
 @import "object/project/related";
+@import "object/project/breadcrumb";
+
 
 @import "object/animation/animation";
 @import "object/animation/transforms";

--- a/resource/assets/sass/object/layout/_service.scss
+++ b/resource/assets/sass/object/layout/_service.scss
@@ -1,0 +1,115 @@
+.l-service {
+
+	@include respond(pc) {	
+		@include center;
+		text-align: center;
+		padding-bottom: 16px;
+		width: 100%;
+	}
+
+	@include respond(tb) {	
+		width: 100%;
+		padding: 0 3.125% 24px;
+		margin-top: 50px;
+		text-align: center;
+		box-shadow: 0 5px 4px 0 rgba(209,209,209,0.50);
+	}
+
+	@include respond(xs) {	
+		width: 100%;
+		padding-bottom: 16px;
+		margin-top: 50px;
+		text-align: center;
+		border-bottom: 1px solid $color-gray-c;
+	}
+}
+
+
+.l-service__ttl {
+
+	@include respond(xs) {
+		@include center;
+	}
+
+	@include respond(tb) {
+		@include center;
+		
+	}
+}
+
+.l-service__cache {
+
+	font-weight: bold;
+
+	@include respond(pc) {
+		@include font-size(28);
+		
+		margin-top: 40px;
+	}
+
+	@include respond(tb) {
+		margin-top: 24px;
+		@include font-size(24);
+	}
+
+	@include respond(xs) {
+		margin-top: 24px;
+		line-height: 1.5;
+		@include font-size(18);
+		padding: 0 4.125% 0;
+		@include widtnPercent( 640, 540 );
+		@include center;
+	}
+}
+
+.l-service__inner__item__col {
+	@include respond(pc) {
+		margin-top: 60px;
+	}
+
+	&:first-child {
+		margin-top: 0px;
+	}
+
+	@include respond(xs) {
+		padding: 0 5.125%;
+		margin-top: 16px;
+	}
+
+	
+}
+
+.l-service__inner {
+
+	@include respond(pc) {
+		position: relative;
+		padding: 40px 0;
+		text-align: left;
+		border-top: 1px solid $color-gray-f2;
+		margin-top: 40px;
+		@include widtnPercent( 640, 566 );
+		max-width: 1060px;
+		@include center;
+	}
+
+	@include respond(tb) {
+		padding: 32px 0px 0px 0px;
+	}
+
+	@include respond(xs) {
+		padding: 0px;
+		background: #fff;
+		margin-top: 16px;
+	}
+
+	> li {
+
+		@include respond(pc) {
+			background: #fff;
+			@include widtnPercent( 618, 186 );
+			margin: 0 1.61%;
+		}
+
+	}
+		
+}

--- a/resource/assets/sass/object/project/_breadcrumb.scss
+++ b/resource/assets/sass/object/project/_breadcrumb.scss
@@ -1,0 +1,30 @@
+.p-breadcrumb {
+	//@include font-size(10);
+
+	li {
+		margin-left: 24px;
+		display: inline-block;
+		border-bottom: 1px solid $color-accent--blue;
+		padding-bottom: 2px;
+		@include font-size(12);
+
+		
+
+		&.is-first {
+			display: inline-block;	
+			margin-left: 0px;
+			padding: 0 4px 2px;
+			border-bottom: 1px solid $color-main;
+			position: relative;
+
+			&::after {
+				content: ">"; 
+				font-size:  small; 
+				color: $color-gray-c;
+				position: absolute;
+				right: -17px;
+				top: -1px;
+			}
+		}
+	}
+}

--- a/wp/wordpress/wp-content/themes/nina/single.php
+++ b/wp/wordpress/wp-content/themes/nina/single.php
@@ -6,6 +6,8 @@
 
 <div class="l-content--lower__item--left">
 
+<?php get_template_part('/template_parts/p-breadcrumb' ); ?>
+
 <?php get_template_part('/template_parts/p-article' ); ?>
 
 </div>

--- a/wp/wordpress/wp-content/themes/nina/template_parts/p-article.php
+++ b/wp/wordpress/wp-content/themes/nina/template_parts/p-article.php
@@ -5,12 +5,12 @@
         while ( have_posts() ) : the_post();
     ?>
 
-    <p class="p-article__ttl c-contentTtl--secondary">
+    <!--<p class="p-article__ttl c-contentTtl--secondary">
       <?php
       $category = get_the_category();
       echo $category[0]->cat_name;
       ?>
-    </p>
+    </p>-->
 
     <h2 class="p-article__cache"><?php the_title(); ?></h2>
 

--- a/wp/wordpress/wp-content/themes/nina/template_parts/p-breadcrumb.php
+++ b/wp/wordpress/wp-content/themes/nina/template_parts/p-breadcrumb.php
@@ -1,0 +1,13 @@
+<ul class="p-breadcrumb">
+<?php if (is_single()) : ?>
+	<li class="is-first"><a href="<?php echo home_url() ?>">TOP</a></li>
+	<li><?php $cat = get_the_category(); echo get_category_parents($cat[0], true, ''); ?></li>
+<?php endif; ?>
+
+<?php if ( is_page() ) : ?>
+	<?php foreach ( array_reverse(get_post_ancestors($post->ID)) as $parid ) { ?>
+	<li class="is-first"><a href="<?php echo home_url() ?>">TOP</a></li>
+	<li><?php $cat = get_the_category(); echo get_category_parents($cat[0], true, ''); ?></li>
+	<?php } ?>
+<?php endif; ?>
+</ul>


### PR DESCRIPTION
シングルページと固定ページに対しての表示実装対応。  
タグページ類は未着手。 記述が増えてめんどうになりそうなら、  
プラグイン(Breadcrumb NavXT)をつかうかも。 